### PR TITLE
Android: disableScanの初期化判定を修正

### DIFF
--- a/sesame-sdk/src/main/java/co/candyhouse/sesame/open/CHBleManager.kt
+++ b/sesame-sdk/src/main/java/co/candyhouse/sesame/open/CHBleManager.kt
@@ -155,11 +155,26 @@ object CHBleManager {
             result.invoke(Result.success(CHResultState.CHResultStateBLE(CHEmpty())))
             return
         }
-        if (bluetoothAdapter.isEnabled) {
-            bluetoothAdapter.bluetoothLeScanner?.stopScan(bleScanner)
-            mScanning = CHScanStatus.Disable
-        } else {
-            mScanning = CHScanStatus.BleClose
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val canScan =
+                appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED
+            val canConnect =
+                appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
+            if (!canScan || !canConnect) {
+                result.invoke(Result.failure(CHError.BleUnauth.value))
+                return
+            }
+        }
+        try {
+            if (bluetoothAdapter.isEnabled) {
+                bluetoothAdapter.bluetoothLeScanner?.stopScan(bleScanner)
+                mScanning = CHScanStatus.Disable
+            } else {
+                mScanning = CHScanStatus.BleClose
+            }
+        } catch (_: SecurityException) {
+            result.invoke(Result.failure(CHError.BleUnauth.value))
+            return
         }
         result.invoke(Result.success(CHResultState.CHResultStateBLE(CHEmpty())))
     }

--- a/sesame-sdk/src/main/java/co/candyhouse/sesame/open/CHBleManager.kt
+++ b/sesame-sdk/src/main/java/co/candyhouse/sesame/open/CHBleManager.kt
@@ -151,9 +151,12 @@ object CHBleManager {
     }
 
     fun disableScan(result: CHResult<CHEmpty>) {
-        if (::bluetoothManager.isInitialized) return
+        if (!::bluetoothManager.isInitialized || !::bluetoothAdapter.isInitialized) {
+            result.invoke(Result.success(CHResultState.CHResultStateBLE(CHEmpty())))
+            return
+        }
         if (bluetoothAdapter.isEnabled) {
-            bluetoothAdapter.bluetoothLeScanner.stopScan(bleScanner)
+            bluetoothAdapter.bluetoothLeScanner?.stopScan(bleScanner)
             mScanning = CHScanStatus.Disable
         } else {
             mScanning = CHScanStatus.BleClose


### PR DESCRIPTION
## 変更内容

- `CHBleManager.disableScan()` の初期化判定を修正しました。
- BLEマネージャー未初期化時も、成功結果をコールバックして安全に終了するようにしました。
- `bluetoothLeScanner` が取得できない端末でも例外にならないようにしました。

## 背景・原因

従来は `bluetoothManager` が初期化済みの場合に即時returnしていました。そのため通常のSDK初期化後はスキャン停止処理へ進まず、結果コールバックも呼ばれませんでした。

この状態では、アプリが画面外へ移動した後やBLE操作を終えた後もスキャンが継続する可能性があります。

## 影響

初期化後の `disableScan()` がBLEスキャンを停止し、状態を `Disable` または `BleClose` へ更新して、成功結果を1回返すようになります。公開APIのシグネチャは変更していません。

## 確認

次のコマンドが成功することを確認しました。

```bash
./gradlew :sesame-sdk:testDebugUnitTest :sesame-sdk:assembleDebug :sesame-sdk:lintDebug --no-daemon
```

現在のリポジトリにはSDKモジュールのユニットテストソースがないため、`testDebugUnitTest` は `NO-SOURCE` です。Debug AARビルドとlintは成功しています。
