### PR TITLE
Add Android shortcut support for SESAME devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,7 @@ dependencies {
 
     implementation libs.androidx.work.runtime
     implementation libs.androidx.core.ktx.v180
+    implementation libs.androidx.lifecycle.viewmodel.ktx.v286
     implementation libs.androidx.preference.ktx
     implementation libs.androidx.swiperefreshlayout
 
@@ -154,4 +155,6 @@ dependencies {
     implementation libs.firebase.analytics.ktx
     implementation libs.firebase.messaging.ktx
     implementation libs.firebase.crashlytics.ktx
+
+    testImplementation libs.junit
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,8 +63,6 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <action android:name="android.intent.action.CREATE_SHORTCUT" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
@@ -74,6 +72,25 @@
 
             <nav-graph android:value="@navigation/devices_ng" />
         </activity>
+
+        <activity
+            android:name=".shortcut.ShortcutCreateActivity"
+            android:exported="true"
+            android:theme="@style/AppTheme.FlatDialog">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <!--exported for MacroDroid-style automation apps to replay the saved shortcut Intent; SesameShortcutAuth's per-install KeyStore token is what actually gates execution.-->
+        <activity
+            android:name=".shortcut.ShortcutExecuteActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@style/AppTheme.ShortcutExecutor" />
 
         <!--注册服务-->
         <service

--- a/app/src/main/java/co/candyhouse/app/shortcut/SesameShortcutAuth.kt
+++ b/app/src/main/java/co/candyhouse/app/shortcut/SesameShortcutAuth.kt
@@ -1,0 +1,51 @@
+package co.candyhouse.app.shortcut
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyStore
+import java.security.MessageDigest
+import javax.crypto.KeyGenerator
+import javax.crypto.Mac
+import javax.crypto.SecretKey
+
+/**
+ * Signs and verifies shortcut capability tokens with a per-install AndroidKeyStore HMAC key.
+ *
+ * ShortcutExecuteActivity is exported so other apps (e.g. MacroDroid) can replay a saved shortcut Intent, which would otherwise let anyone forge a (deviceId, action) pair. The key never leaves the KeyStore, so only this install can mint a valid token; clearing app data invalidates every existing shortcut.
+ */
+object SesameShortcutAuth {
+    private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    private const val KEY_ALIAS = "sesame_shortcut_hmac_key"
+
+    fun sign(deviceId: String, action: SesameShortcutAction): String =
+        hmac(deviceId, action).joinToString(separator = "") { "%02x".format(it) }
+
+    fun verify(deviceId: String, action: SesameShortcutAction, token: String?): Boolean {
+        if (token.isNullOrEmpty()) return false
+        val expected = sign(deviceId, action)
+        return MessageDigest.isEqual(
+            expected.toByteArray(Charsets.US_ASCII),
+            token.toByteArray(Charsets.US_ASCII),
+        )
+    }
+
+    private fun hmac(deviceId: String, action: SesameShortcutAction): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(getOrCreateKey())
+        return mac.doFinal(SesameShortcutContract.tokenMessage(deviceId, action))
+    }
+
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_HMAC_SHA256,
+            ANDROID_KEYSTORE,
+        )
+        keyGenerator.init(
+            KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY).build(),
+        )
+        return keyGenerator.generateKey()
+    }
+}

--- a/app/src/main/java/co/candyhouse/app/shortcut/SesameShortcutContract.kt
+++ b/app/src/main/java/co/candyhouse/app/shortcut/SesameShortcutContract.kt
@@ -1,0 +1,31 @@
+package co.candyhouse.app.shortcut
+
+object SesameShortcutContract {
+    const val ACTION_EXECUTE = "co.candyhouse.sesame2.action.EXECUTE_SHORTCUT"
+    const val EXTRA_DEVICE_ID = "co.candyhouse.sesame2.extra.DEVICE_ID"
+    const val EXTRA_ACTION = "co.candyhouse.sesame2.extra.SHORTCUT_ACTION"
+    const val EXTRA_AUTH_TOKEN = "co.candyhouse.sesame2.extra.SHORTCUT_TOKEN"
+
+    private const val SHORTCUT_ID_PREFIX = "sesame_shortcut"
+    private const val TOKEN_VERSION = "v1"
+
+    fun shortcutId(deviceId: String, action: SesameShortcutAction): String =
+        "$SHORTCUT_ID_PREFIX:${deviceId.lowercase()}:${action.wireName}"
+
+    /** Bound to (version, deviceId, action) so tampering with either extra invalidates the token. */
+    fun tokenMessage(deviceId: String, action: SesameShortcutAction): ByteArray =
+        "$TOKEN_VERSION:${deviceId.lowercase()}:${action.wireName}".toByteArray(Charsets.UTF_8)
+}
+
+/** [wireName] is persisted in shortcuts and must remain stable. */
+enum class SesameShortcutAction(val wireName: String) {
+    LOCK("lock"),
+    UNLOCK("unlock"),
+    TOGGLE("toggle"),
+    CLICK("click");
+
+    companion object {
+        fun fromWireName(value: String?): SesameShortcutAction? =
+            entries.firstOrNull { it.wireName == value }
+    }
+}

--- a/app/src/main/java/co/candyhouse/app/shortcut/SesameShortcutDeviceKind.kt
+++ b/app/src/main/java/co/candyhouse/app/shortcut/SesameShortcutDeviceKind.kt
@@ -1,0 +1,41 @@
+package co.candyhouse.app.shortcut
+
+import co.candyhouse.sesame.open.devices.CHSesame2
+import co.candyhouse.sesame.open.devices.CHSesame5
+import co.candyhouse.sesame.open.devices.CHSesameBike
+import co.candyhouse.sesame.open.devices.CHSesameBike2
+import co.candyhouse.sesame.open.devices.CHSesameBot
+import co.candyhouse.sesame.open.devices.CHSesameBot2
+import co.candyhouse.sesame.open.devices.base.CHDevices
+import co.candyhouse.app.shortcut.SesameShortcutAction.CLICK
+import co.candyhouse.app.shortcut.SesameShortcutAction.LOCK
+import co.candyhouse.app.shortcut.SesameShortcutAction.TOGGLE
+import co.candyhouse.app.shortcut.SesameShortcutAction.UNLOCK
+
+enum class SesameShortcutDeviceKind {
+    SESAME5,
+    SESAME2,
+    BIKE,
+    BIKE2,
+    BOT,
+    BOT2,
+}
+
+fun SesameShortcutDeviceKind.supportedActions(): Set<SesameShortcutAction> = when (this) {
+    SesameShortcutDeviceKind.SESAME5, SesameShortcutDeviceKind.SESAME2 -> setOf(LOCK, UNLOCK, TOGGLE)
+    SesameShortcutDeviceKind.BIKE, SesameShortcutDeviceKind.BIKE2 -> setOf(UNLOCK)
+    SesameShortcutDeviceKind.BOT, SesameShortcutDeviceKind.BOT2 -> setOf(CLICK)
+}
+
+fun SesameShortcutDeviceKind.supports(action: SesameShortcutAction): Boolean =
+    action in supportedActions()
+
+fun CHDevices.toShortcutDeviceKindOrNull(): SesameShortcutDeviceKind? = when (this) {
+    is CHSesame5 -> SesameShortcutDeviceKind.SESAME5
+    is CHSesame2 -> SesameShortcutDeviceKind.SESAME2
+    is CHSesameBike2 -> SesameShortcutDeviceKind.BIKE2
+    is CHSesameBike -> SesameShortcutDeviceKind.BIKE
+    is CHSesameBot2 -> SesameShortcutDeviceKind.BOT2
+    is CHSesameBot -> SesameShortcutDeviceKind.BOT
+    else -> null
+}

--- a/app/src/main/java/co/candyhouse/app/shortcut/SesameShortcutExecutor.kt
+++ b/app/src/main/java/co/candyhouse/app/shortcut/SesameShortcutExecutor.kt
@@ -1,0 +1,268 @@
+package co.candyhouse.app.shortcut
+
+import co.candyhouse.sesame.open.CHBleManager
+import co.candyhouse.sesame.open.CHDeviceManager
+import co.candyhouse.sesame.open.CHScanStatus
+import co.candyhouse.sesame.open.devices.CHSesame2
+import co.candyhouse.sesame.open.devices.CHSesame5
+import co.candyhouse.sesame.open.devices.CHSesameBike
+import co.candyhouse.sesame.open.devices.CHSesameBike2
+import co.candyhouse.sesame.open.devices.CHSesameBot
+import co.candyhouse.sesame.open.devices.CHSesameBot2
+import co.candyhouse.sesame.open.devices.base.CHDeviceLoginStatus
+import co.candyhouse.sesame.open.devices.base.CHDeviceStatus
+import co.candyhouse.sesame.open.devices.base.CHDevices
+import co.candyhouse.sesame.open.devices.base.CHSesameLock
+import co.candyhouse.sesame.utils.CHEmpty
+import co.candyhouse.sesame.utils.CHResult
+import co.utils.UserUtils
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+sealed interface SesameShortcutResult {
+    data object Success : SesameShortcutResult
+    data object DeviceNotFound : SesameShortcutResult
+    data object DeviceLookupFailed : SesameShortcutResult
+    data object UnsupportedAction : SesameShortcutResult
+    data object PreparationTimedOut : SesameShortcutResult
+    data object CommandOutcomeUnknown : SesameShortcutResult
+    data object Failed : SesameShortcutResult
+}
+
+private sealed interface DeviceLookupResult {
+    data class Found(val device: CHDevices) : DeviceLookupResult
+    data object NotFound : DeviceLookupResult
+    data object Failed : DeviceLookupResult
+}
+
+internal enum class ShortcutCommandPath {
+    BLE,
+    IOT,
+}
+
+internal enum class ShortcutCommandFailurePolicy {
+    TERMINAL,
+    WAIT_FOR_SUCCESS,
+}
+
+/** Some SDK families emit a BLE failure before completing their IoT fallback callback. */
+internal fun shortcutCommandFailurePolicy(
+    kind: SesameShortcutDeviceKind,
+): ShortcutCommandFailurePolicy = when (kind) {
+    SesameShortcutDeviceKind.SESAME5,
+    SesameShortcutDeviceKind.BIKE2,
+    SesameShortcutDeviceKind.BOT,
+    SesameShortcutDeviceKind.BOT2,
+    -> ShortcutCommandFailurePolicy.WAIT_FOR_SUCCESS
+
+    SesameShortcutDeviceKind.SESAME2,
+    SesameShortcutDeviceKind.BIKE,
+    -> ShortcutCommandFailurePolicy.TERMINAL
+}
+
+object SesameShortcutExecutor {
+
+    private const val DEVICE_LOOKUP_TIMEOUT_MS = 3_000L
+    private const val READINESS_TIMEOUT_MS = 9_000L
+    private const val READINESS_POLL_INTERVAL_MS = 500L
+    private const val COMMAND_TIMEOUT_MS = 8_000L
+
+    suspend fun execute(deviceId: String, action: SesameShortcutAction): SesameShortcutResult {
+        var scanStartedByShortcut = false
+
+        return try {
+            val lookup = withTimeoutOrNull(DEVICE_LOOKUP_TIMEOUT_MS) {
+                findDevice(deviceId)
+            } ?: return SesameShortcutResult.PreparationTimedOut
+
+            val device = when (lookup) {
+                is DeviceLookupResult.Found -> lookup.device
+                DeviceLookupResult.NotFound -> return SesameShortcutResult.DeviceNotFound
+                DeviceLookupResult.Failed -> return SesameShortcutResult.DeviceLookupFailed
+            }
+
+            val kind = device.toShortcutDeviceKindOrNull()
+            if (kind == null || !kind.supports(action)) {
+                return SesameShortcutResult.UnsupportedAction
+            }
+
+            try {
+                scanStartedByShortcut = startBleScanIfNeeded(device)
+
+                awaitCommandPath(device)
+                    ?: return SesameShortcutResult.PreparationTimedOut
+
+                // Never use a physical command as a connectivity probe.
+                currentCommandPath(device)
+                    ?: return SesameShortcutResult.Failed
+
+                val historyTag = UserUtils.getEnvironmentIdWithByte()
+                val commandResult = withTimeoutOrNull(COMMAND_TIMEOUT_MS) {
+                    executeOnce(device, kind, action, historyTag)
+                } ?: return SesameShortcutResult.CommandOutcomeUnknown
+
+                if (commandResult) SesameShortcutResult.Success else SesameShortcutResult.Failed
+            } finally {
+                if (scanStartedByShortcut) {
+                    CHBleManager.disableScan { }
+                }
+            }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            SesameShortcutResult.Failed
+        }
+    }
+
+    private suspend fun findDevice(deviceId: String): DeviceLookupResult =
+        suspendCancellableCoroutine { continuation ->
+            CHDeviceManager.getCandyDevices { result ->
+                if (!continuation.isActive) return@getCandyDevices
+
+                result.onSuccess { state ->
+                    if (!continuation.isActive) return@onSuccess
+                    val match = state.data.firstOrNull {
+                        it.deviceId?.toString()?.equals(deviceId, ignoreCase = true) == true
+                    }
+                    continuation.resume(
+                        match?.let { DeviceLookupResult.Found(it) } ?: DeviceLookupResult.NotFound,
+                    )
+                }
+
+                result.onFailure {
+                    if (!continuation.isActive) return@onFailure
+                    continuation.resume(DeviceLookupResult.Failed)
+                }
+            }
+        }
+
+    private fun startBleScanIfNeeded(device: CHDevices): Boolean {
+        val lockDevice = device as? CHSesameLock ?: return false
+        if (currentCommandPath(lockDevice) != null || CHBleManager.mScanning == CHScanStatus.Enable) {
+            return false
+        }
+
+        CHBleManager.enableScan(true) { }
+        return CHBleManager.mScanning == CHScanStatus.Enable
+    }
+
+    private suspend fun awaitCommandPath(device: CHDevices): ShortcutCommandPath? =
+        withTimeoutOrNull(READINESS_TIMEOUT_MS) {
+            while (true) {
+                val path = currentCommandPath(device)
+                if (path != null) {
+                    return@withTimeoutOrNull path
+                }
+                connectIfAdvertisementReceived(device)
+                delay(READINESS_POLL_INTERVAL_MS)
+            }
+            @Suppress("UNREACHABLE_CODE")
+            null
+        }
+
+    private fun connectIfAdvertisementReceived(device: CHDevices) {
+        val lockDevice = device as? CHSesameLock ?: return
+        if (lockDevice.deviceStatus == CHDeviceStatus.ReceivedAdV) {
+            lockDevice.connect { }
+        }
+    }
+
+    private fun currentCommandPath(device: CHDevices): ShortcutCommandPath? {
+        val lockDevice = device as? CHSesameLock ?: return null
+        return when {
+            lockDevice.deviceStatus.value == CHDeviceLoginStatus.logined -> ShortcutCommandPath.BLE
+            lockDevice.deviceShadowStatus != null -> ShortcutCommandPath.IOT
+            else -> null
+        }
+    }
+
+    private suspend fun executeOnce(
+        device: CHDevices,
+        kind: SesameShortcutDeviceKind,
+        action: SesameShortcutAction,
+        historyTag: ByteArray?,
+    ): Boolean {
+        val failurePolicy = shortcutCommandFailurePolicy(kind)
+
+        return when (kind) {
+            SesameShortcutDeviceKind.SESAME5 -> {
+                val d = device as CHSesame5
+                when (action) {
+                    SesameShortcutAction.LOCK -> awaitCommand(failurePolicy) { d.lock(historytag = historyTag, result = it) }
+                    SesameShortcutAction.UNLOCK -> awaitCommand(failurePolicy) { d.unlock(historytag = historyTag, result = it) }
+                    SesameShortcutAction.TOGGLE -> awaitCommand(failurePolicy) { d.toggle(historytag = historyTag, result = it) }
+                    SesameShortcutAction.CLICK -> false
+                }
+            }
+
+            SesameShortcutDeviceKind.SESAME2 -> {
+                val d = device as CHSesame2
+                when (action) {
+                    SesameShortcutAction.LOCK -> awaitCommand(failurePolicy) { d.lock(result = it) }
+                    SesameShortcutAction.UNLOCK -> awaitCommand(failurePolicy) { d.unlock(result = it) }
+                    SesameShortcutAction.TOGGLE -> awaitCommand(failurePolicy) { d.toggle(result = it) }
+                    SesameShortcutAction.CLICK -> false
+                }
+            }
+
+            SesameShortcutDeviceKind.BIKE -> {
+                val d = device as CHSesameBike
+                if (action == SesameShortcutAction.UNLOCK) {
+                    awaitCommand(failurePolicy) { d.unlock(result = it) }
+                } else {
+                    false
+                }
+            }
+
+            SesameShortcutDeviceKind.BIKE2 -> {
+                val d = device as CHSesameBike2
+                if (action == SesameShortcutAction.UNLOCK) {
+                    awaitCommand(failurePolicy) { d.unlock(historytag = historyTag, result = it) }
+                } else {
+                    false
+                }
+            }
+
+            SesameShortcutDeviceKind.BOT -> {
+                val d = device as CHSesameBot
+                if (action == SesameShortcutAction.CLICK) {
+                    awaitCommand(failurePolicy) { d.click(result = it) }
+                } else {
+                    false
+                }
+            }
+
+            SesameShortcutDeviceKind.BOT2 -> {
+                val d = device as CHSesameBot2
+                if (action == SesameShortcutAction.CLICK) {
+                    awaitCommand(failurePolicy) { d.click(historytag = historyTag, result = it) }
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    private suspend fun awaitCommand(
+        failurePolicy: ShortcutCommandFailurePolicy,
+        command: (CHResult<CHEmpty>) -> Unit,
+    ): Boolean = suspendCancellableCoroutine { continuation ->
+        try {
+            command { result ->
+                if (!continuation.isActive) return@command
+                when {
+                    result.isSuccess -> continuation.resume(true)
+                    failurePolicy == ShortcutCommandFailurePolicy.TERMINAL -> continuation.resume(false)
+                    else -> Unit
+                }
+            }
+        } catch (_: Exception) {
+            if (continuation.isActive) {
+                continuation.resume(false)
+            }
+        }
+    }
+}

--- a/app/src/main/java/co/candyhouse/app/shortcut/ShortcutCreateActivity.kt
+++ b/app/src/main/java/co/candyhouse/app/shortcut/ShortcutCreateActivity.kt
@@ -1,0 +1,148 @@
+package co.candyhouse.app.shortcut
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import co.candyhouse.app.R
+import co.candyhouse.app.tabs.devices.ssm2.getNickname
+import co.candyhouse.sesame.open.CHDeviceManager
+import co.candyhouse.sesame.open.devices.base.CHDevices
+
+class ShortcutCreateActivity : AppCompatActivity() {
+
+    private var activeDialog: AlertDialog? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (intent?.action != Intent.ACTION_CREATE_SHORTCUT) {
+            cancelAndFinish()
+            return
+        }
+
+        loadDevices()
+    }
+
+    override fun onDestroy() {
+        activeDialog?.dismiss()
+        activeDialog = null
+        super.onDestroy()
+    }
+
+    private fun loadDevices() {
+        CHDeviceManager.getCandyDevices { result ->
+            if (isFinishing || isDestroyed) return@getCandyDevices
+
+            result.onSuccess { state ->
+                val devices = state.data.filter { isShortcutSupported(it) }
+                runOnUiThread {
+                    if (isFinishing || isDestroyed) return@runOnUiThread
+                    if (devices.isEmpty()) {
+                        showMessageAndFinish(getString(R.string.shortcut_no_supported_devices))
+                        return@runOnUiThread
+                    }
+                    showDeviceChooser(devices)
+                }
+            }
+            result.onFailure {
+                runOnUiThread {
+                    if (isFinishing || isDestroyed) return@runOnUiThread
+                    showMessageAndFinish(getString(R.string.shortcut_load_devices_failed))
+                }
+            }
+        }
+    }
+
+    private fun showDeviceChooser(devices: List<CHDevices>) {
+        val labels = devices.map { it.getNickname() }.toTypedArray()
+
+        activeDialog = AlertDialog.Builder(this)
+            .setTitle(R.string.shortcut_choose_device)
+            .setItems(labels) { _, index -> showActionChooser(devices[index]) }
+            .setNegativeButton(android.R.string.cancel) { _, _ -> cancelAndFinish() }
+            .setOnCancelListener { cancelAndFinish() }
+            .show()
+    }
+
+    private fun showActionChooser(device: CHDevices) {
+        val kind = device.toShortcutDeviceKindOrNull()
+        if (kind == null) {
+            showMessageAndFinish(getString(R.string.shortcut_invalid_device))
+            return
+        }
+
+        val actions = kind.supportedActions().sortedBy { it.ordinal }
+        val labels = actions.map { getString(it.labelRes()) }.toTypedArray()
+
+        activeDialog = AlertDialog.Builder(this)
+            .setTitle(device.getNickname())
+            .setItems(labels) { _, index -> returnShortcut(device, actions[index]) }
+            .setNegativeButton(android.R.string.cancel) { _, _ -> cancelAndFinish() }
+            .setOnCancelListener { cancelAndFinish() }
+            .show()
+    }
+
+    private fun returnShortcut(device: CHDevices, shortcutAction: SesameShortcutAction) {
+        val deviceId = device.deviceId?.toString()
+        if (deviceId.isNullOrBlank()) {
+            showMessageAndFinish(getString(R.string.shortcut_invalid_device))
+            return
+        }
+
+        val executeIntent = Intent(this, ShortcutExecuteActivity::class.java).apply {
+            action = SesameShortcutContract.ACTION_EXECUTE
+            putExtra(SesameShortcutContract.EXTRA_DEVICE_ID, deviceId)
+            putExtra(SesameShortcutContract.EXTRA_ACTION, shortcutAction.wireName)
+            putExtra(SesameShortcutContract.EXTRA_AUTH_TOKEN, SesameShortcutAuth.sign(deviceId, shortcutAction))
+        }
+
+        val label = getString(
+            R.string.shortcut_label_format,
+            device.getNickname(),
+            getString(shortcutAction.labelRes()),
+        )
+
+        val shortcut = ShortcutInfoCompat.Builder(
+            this,
+            SesameShortcutContract.shortcutId(deviceId, shortcutAction),
+        )
+            .setShortLabel(label)
+            .setLongLabel(label)
+            .setIcon(IconCompat.createWithResource(this, R.drawable.app_icon))
+            .setIntent(executeIntent)
+            .build()
+
+        val resultIntent = ShortcutManagerCompat.createShortcutResultIntent(this, shortcut)
+        setResult(Activity.RESULT_OK, resultIntent)
+        finish()
+    }
+
+    private fun isShortcutSupported(device: CHDevices): Boolean =
+        device.deviceId != null && device.toShortcutDeviceKindOrNull() != null
+
+    private fun showMessageAndFinish(message: String) {
+        activeDialog = AlertDialog.Builder(this)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok) { _, _ -> cancelAndFinish() }
+            .setOnCancelListener { cancelAndFinish() }
+            .show()
+    }
+
+    private fun cancelAndFinish() {
+        if (isFinishing) return
+        setResult(Activity.RESULT_CANCELED)
+        finish()
+    }
+}
+
+private fun SesameShortcutAction.labelRes(): Int = when (this) {
+    SesameShortcutAction.LOCK -> R.string.shortcut_action_lock
+    SesameShortcutAction.UNLOCK -> R.string.shortcut_action_unlock
+    SesameShortcutAction.TOGGLE -> R.string.shortcut_action_toggle
+    SesameShortcutAction.CLICK -> R.string.shortcut_action_click
+}

--- a/app/src/main/java/co/candyhouse/app/shortcut/ShortcutExecuteActivity.kt
+++ b/app/src/main/java/co/candyhouse/app/shortcut/ShortcutExecuteActivity.kt
@@ -1,0 +1,85 @@
+package co.candyhouse.app.shortcut
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.ViewModelProvider
+import co.candyhouse.app.R
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+class ShortcutExecuteActivity : ComponentActivity() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var observerJob: Job? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val executeIntent = intent?.takeIf { it.action == SesameShortcutContract.ACTION_EXECUTE }
+        val deviceId = executeIntent?.getStringExtra(SesameShortcutContract.EXTRA_DEVICE_ID)
+        val action = SesameShortcutAction.fromWireName(
+            executeIntent?.getStringExtra(SesameShortcutContract.EXTRA_ACTION),
+        )
+        val token = executeIntent?.getStringExtra(SesameShortcutContract.EXTRA_AUTH_TOKEN)
+
+        // The token, not the exported flag, is what stops other apps from forging a (deviceId, action) pair.
+        if (deviceId.isNullOrBlank() || action == null || !SesameShortcutAuth.verify(deviceId, action, token)) {
+            finish()
+            return
+        }
+
+        val viewModel = ViewModelProvider(this)[ShortcutExecutionViewModel::class.java]
+        val execution = viewModel.executionOrStart(
+            deviceId = deviceId,
+            action = action,
+            // After process recreation the previous physical outcome is unknown; never resend.
+            allowStart = savedInstanceState == null,
+        )
+
+        if (execution == null) {
+            showFailureToast()
+            finish()
+            return
+        }
+
+        observerJob = scope.launch {
+            val result = try {
+                execution.await()
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (_: Exception) {
+                SesameShortcutResult.Failed
+            }
+
+            when (result) {
+                SesameShortcutResult.Success -> Unit
+
+                SesameShortcutResult.DeviceNotFound,
+                SesameShortcutResult.DeviceLookupFailed,
+                SesameShortcutResult.UnsupportedAction,
+                SesameShortcutResult.PreparationTimedOut,
+                SesameShortcutResult.CommandOutcomeUnknown,
+                SesameShortcutResult.Failed,
+                -> showFailureToast()
+            }
+            finish()
+        }
+    }
+
+    override fun onDestroy() {
+        // The ViewModel owns execution; only stop this Activity's observer.
+        observerJob?.cancel()
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private fun showFailureToast() {
+        Toast.makeText(applicationContext, R.string.shortcut_execution_failed, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/co/candyhouse/app/shortcut/ShortcutExecutionViewModel.kt
+++ b/app/src/main/java/co/candyhouse/app/shortcut/ShortcutExecutionViewModel.kt
@@ -1,0 +1,27 @@
+package co.candyhouse.app.shortcut
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+
+/** Keeps one physical execution alive across Activity recreation. */
+class ShortcutExecutionViewModel : ViewModel() {
+
+    private var execution: Deferred<SesameShortcutResult>? = null
+
+    fun executionOrStart(
+        deviceId: String,
+        action: SesameShortcutAction,
+        allowStart: Boolean,
+    ): Deferred<SesameShortcutResult>? {
+        execution?.let { return it }
+        if (!allowStart) return null
+
+        return viewModelScope.async {
+            SesameShortcutExecutor.execute(deviceId, action)
+        }.also {
+            execution = it
+        }
+    }
+}

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -247,6 +247,17 @@
     <string name="dBm">dBm</string>
     <string name="set_switch_point_position">切替点</string>
     <string name="dfu_busy">他のCANDY HOUSE製品を更新中、お待ち下さいませ。</string>
+
+    <string name="shortcut_choose_device">SESAMEデバイスを選択</string>
+    <string name="shortcut_no_supported_devices">ショートカットに対応するSESAMEデバイスがありません。</string>
+    <string name="shortcut_load_devices_failed">SESAMEデバイスを読み込めませんでした。</string>
+    <string name="shortcut_invalid_device">このデバイスはショートカットに使用できません。</string>
+    <string name="shortcut_execution_failed">SESAMEデバイスを操作できませんでした。</string>
+    <string name="shortcut_action_lock">施錠</string>
+    <string name="shortcut_action_unlock">解錠</string>
+    <string name="shortcut_action_toggle">トグル</string>
+    <string name="shortcut_action_click">クリック</string>
+    <string name="shortcut_label_format">%1$s：%2$s</string>
 </resources>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,4 +256,15 @@
     <string name="dBm">dBm</string>
     <string name="set_switch_point_position">Switch point</string>
     <string name="dfu_busy">Updating another CANDY HOUSE product. Please wait...</string>
+
+    <string name="shortcut_choose_device">Choose a SESAME device</string>
+    <string name="shortcut_no_supported_devices">No supported SESAME devices are registered.</string>
+    <string name="shortcut_load_devices_failed">Could not load SESAME devices.</string>
+    <string name="shortcut_invalid_device">This device cannot be used for a shortcut.</string>
+    <string name="shortcut_execution_failed">Could not operate the SESAME device.</string>
+    <string name="shortcut_action_lock">Lock</string>
+    <string name="shortcut_action_unlock">Unlock</string>
+    <string name="shortcut_action_toggle">Toggle</string>
+    <string name="shortcut_action_click">Click</string>
+    <string name="shortcut_label_format">%1$s: %2$s</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,6 +13,8 @@
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
     </style>
     <style name="AppTheme.FlatDialog" parent="Theme.AppCompat.Light.Dialog">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
         <item name="colorAccent">@color/colorPrimary</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowIsTranslucent">false</item>
@@ -23,6 +25,15 @@
         <item name="android:backgroundDimEnabled">true</item>
         <item name="android:backgroundDimAmount">0.4</item>
 
+    </style>
+
+    <style name="AppTheme.ShortcutExecutor" parent="android:Theme.Translucent.NoTitleBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
     </style>
 
     <style name="CustomBottomSheetDialogTheme" parent="Theme.Design.Light.BottomSheetDialog">

--- a/app/src/test/java/co/candyhouse/app/shortcut/SesameShortcutContractTest.kt
+++ b/app/src/test/java/co/candyhouse/app/shortcut/SesameShortcutContractTest.kt
@@ -1,0 +1,81 @@
+package co.candyhouse.app.shortcut
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SesameShortcutContractTest {
+
+    @Test
+    fun `fromWireName resolves every declared action by its stable wire string`() {
+        assertEquals(SesameShortcutAction.LOCK, SesameShortcutAction.fromWireName("lock"))
+        assertEquals(SesameShortcutAction.UNLOCK, SesameShortcutAction.fromWireName("unlock"))
+        assertEquals(SesameShortcutAction.TOGGLE, SesameShortcutAction.fromWireName("toggle"))
+        assertEquals(SesameShortcutAction.CLICK, SesameShortcutAction.fromWireName("click"))
+    }
+
+    @Test
+    fun `fromWireName rejects unknown, blank, and null values`() {
+        assertNull(SesameShortcutAction.fromWireName("unknown"))
+        assertNull(SesameShortcutAction.fromWireName(""))
+        assertNull(SesameShortcutAction.fromWireName(null))
+        assertNull(SesameShortcutAction.fromWireName("LOCK")) // wire names are lowercase-only
+    }
+
+    @Test
+    fun `wireName round trips through fromWireName for every action`() {
+        SesameShortcutAction.entries.forEach { action ->
+            assertEquals(action, SesameShortcutAction.fromWireName(action.wireName))
+        }
+    }
+
+    @Test
+    fun `shortcutId is stable and distinct per device and action`() {
+        val deviceId = "AABBCCDD-1234-5678-9900-AABBCCDDEEFF"
+
+        val lockId = SesameShortcutContract.shortcutId(deviceId, SesameShortcutAction.LOCK)
+        val unlockId = SesameShortcutContract.shortcutId(deviceId, SesameShortcutAction.UNLOCK)
+
+        assertEquals(lockId, SesameShortcutContract.shortcutId(deviceId, SesameShortcutAction.LOCK))
+        assertNotEquals("shortcut ids for different actions on the same device must differ", lockId, unlockId)
+    }
+
+    @Test
+    fun `shortcutId is case insensitive on the device id`() {
+        val lower = SesameShortcutContract.shortcutId("aabbccdd", SesameShortcutAction.TOGGLE)
+        val upper = SesameShortcutContract.shortcutId("AABBCCDD", SesameShortcutAction.TOGGLE)
+
+        assertEquals(lower, upper)
+    }
+
+    @Test
+    fun `shortcutId differs across devices for the same action`() {
+        val first = SesameShortcutContract.shortcutId("device-1", SesameShortcutAction.CLICK)
+        val second = SesameShortcutContract.shortcutId("device-2", SesameShortcutAction.CLICK)
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun `tokenMessage is stable and case insensitive on the device id`() {
+        val lower = SesameShortcutContract.tokenMessage("aabbccdd", SesameShortcutAction.LOCK)
+        val upper = SesameShortcutContract.tokenMessage("AABBCCDD", SesameShortcutAction.LOCK)
+
+        assertArrayEquals(lower, upper)
+    }
+
+    @Test
+    fun `tokenMessage differs across devices and actions`() {
+        val deviceId = "device-1"
+
+        val byDevice = SesameShortcutContract.tokenMessage(deviceId, SesameShortcutAction.LOCK)
+        val otherDevice = SesameShortcutContract.tokenMessage("device-2", SesameShortcutAction.LOCK)
+        val otherAction = SesameShortcutContract.tokenMessage(deviceId, SesameShortcutAction.UNLOCK)
+
+        assertFalse(byDevice.contentEquals(otherDevice))
+        assertFalse(byDevice.contentEquals(otherAction))
+    }
+}

--- a/app/src/test/java/co/candyhouse/app/shortcut/SesameShortcutDeviceKindTest.kt
+++ b/app/src/test/java/co/candyhouse/app/shortcut/SesameShortcutDeviceKindTest.kt
@@ -1,0 +1,49 @@
+package co.candyhouse.app.shortcut
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SesameShortcutDeviceKindTest {
+
+    @Test
+    fun `sesame 5 and sesame 2 support lock, unlock and toggle only`() {
+        val expected = setOf(SesameShortcutAction.LOCK, SesameShortcutAction.UNLOCK, SesameShortcutAction.TOGGLE)
+
+        assertEquals(expected, SesameShortcutDeviceKind.SESAME5.supportedActions())
+        assertEquals(expected, SesameShortcutDeviceKind.SESAME2.supportedActions())
+    }
+
+    @Test
+    fun `bike and bike2 support unlock only`() {
+        assertEquals(setOf(SesameShortcutAction.UNLOCK), SesameShortcutDeviceKind.BIKE.supportedActions())
+        assertEquals(setOf(SesameShortcutAction.UNLOCK), SesameShortcutDeviceKind.BIKE2.supportedActions())
+    }
+
+    @Test
+    fun `bot and bot2 support click only`() {
+        assertEquals(setOf(SesameShortcutAction.CLICK), SesameShortcutDeviceKind.BOT.supportedActions())
+        assertEquals(setOf(SesameShortcutAction.CLICK), SesameShortcutDeviceKind.BOT2.supportedActions())
+    }
+
+    @Test
+    fun `supports reflects the per-kind action matrix`() {
+        assertTrue(SesameShortcutDeviceKind.SESAME5.supports(SesameShortcutAction.LOCK))
+        assertFalse(SesameShortcutDeviceKind.SESAME5.supports(SesameShortcutAction.CLICK))
+
+        assertTrue(SesameShortcutDeviceKind.BIKE2.supports(SesameShortcutAction.UNLOCK))
+        assertFalse(SesameShortcutDeviceKind.BIKE2.supports(SesameShortcutAction.LOCK))
+        assertFalse(SesameShortcutDeviceKind.BIKE2.supports(SesameShortcutAction.TOGGLE))
+
+        assertTrue(SesameShortcutDeviceKind.BOT2.supports(SesameShortcutAction.CLICK))
+        assertFalse(SesameShortcutDeviceKind.BOT2.supports(SesameShortcutAction.UNLOCK))
+    }
+
+    @Test
+    fun `every device kind supports at least one action`() {
+        SesameShortcutDeviceKind.entries.forEach { kind ->
+            assertTrue("$kind must support at least one shortcut action", kind.supportedActions().isNotEmpty())
+        }
+    }
+}

--- a/app/src/test/java/co/candyhouse/app/shortcut/SesameShortcutExecutorPolicyTest.kt
+++ b/app/src/test/java/co/candyhouse/app/shortcut/SesameShortcutExecutorPolicyTest.kt
@@ -1,0 +1,39 @@
+package co.candyhouse.app.shortcut
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SesameShortcutExecutorPolicyTest {
+
+    @Test
+    fun `device kinds with SDK transport fallback wait for a possible later success`() {
+        val waitForSuccess = setOf(
+            SesameShortcutDeviceKind.SESAME5,
+            SesameShortcutDeviceKind.BIKE2,
+            SesameShortcutDeviceKind.BOT,
+            SesameShortcutDeviceKind.BOT2,
+        )
+
+        waitForSuccess.forEach { kind ->
+            assertEquals(
+                "$kind may report a transport failure before an IoT callback",
+                ShortcutCommandFailurePolicy.WAIT_FOR_SUCCESS,
+                shortcutCommandFailurePolicy(kind),
+            )
+        }
+    }
+
+    @Test
+    fun `OS2 lock and bike failures are terminal`() {
+        listOf(
+            SesameShortcutDeviceKind.SESAME2,
+            SesameShortcutDeviceKind.BIKE,
+        ).forEach { kind ->
+            assertEquals(
+                "$kind should use terminal failure semantics",
+                ShortcutCommandFailurePolicy.TERMINAL,
+                shortcutCommandFailurePolicy(kind),
+            )
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ dfu = "2.5.0"
 easypermissions = "3.0.0"
 firebaseBom = "33.4.0"
 indicatorseekbar = "2.1.2"
+junit = "4.13.2"
 kotlinxCoroutinesAndroid = "1.7.3"
 lifecycleExtensions = "2.2.0"
 lifecycleRuntimeKtx = "2.8.6"
@@ -73,6 +74,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-viewbinding = { group = "androidx.compose.ui", name = "ui-viewbinding", version.ref = "uiViewbinding" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
+junit = { module = "junit:junit", version.ref = "junit" }
 loopview = { module = "com.weigan:loopView", version.ref = "loopview" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }

--- a/sesame-sdk/src/main/java/co/candyhouse/sesame/ble/os3/CHSesame5Device.kt
+++ b/sesame-sdk/src/main/java/co/candyhouse/sesame/ble/os3/CHSesame5Device.kt
@@ -150,7 +150,7 @@ internal class CHSesame5Device : CHSesameOS3LockBase(), CHSesame5 {
             return
         }
         if (!isBleAvailable(result)) {
-            CHAPIClientBiz.cmdSesame(SesameItemCode.toggle, this, sesame2KeyData!!.historyTagIOT(historytag), result)
+            CHAPIClientBiz.cmdSesame(SesameItemCode.unlock, this, sesame2KeyData!!.historyTagIOT(historytag), result)
             return
         }
         sendCommand(
@@ -171,7 +171,7 @@ internal class CHSesame5Device : CHSesameOS3LockBase(), CHSesame5 {
             return
         }
         if (!isBleAvailable(result)) {
-            CHAPIClientBiz.cmdSesame(SesameItemCode.toggle, this, sesame2KeyData!!.historyTagIOT(historytag), result)
+            CHAPIClientBiz.cmdSesame(SesameItemCode.lock, this, sesame2KeyData!!.historyTagIOT(historytag), result)
             return
         }
         sendCommand(


### PR DESCRIPTION
## 概要

Android の `ACTION_CREATE_SHORTCUT` を利用して、SESAMEデバイスを操作するショートカットを作成・実行できるようにします。

MacroDroid などの自動化アプリやランチャーから、通常のアプリ画面を開かずにSESAMEを操作できます。

対応する操作は以下です。

- SESAME: 施錠 / 解錠 / トグル
- SESAME Bike: 解錠
- SESAME Bot: クリック

## 実装内容

- デバイスと操作内容を選択する `ShortcutCreateActivity` を追加
- 通常の `MainActivity` を前面に出さずにショートカットを実行する `ShortcutExecuteActivity` を追加
- 既存のSESAME SDKを利用し、利用可能な場合はBLE、対応デバイスではIoT経由でも操作
- Activityの再生成時に Toggle / Bot Click などの物理操作が重複実行されないよう、実行状態をActivityのライフサイクルから分離
- BLE接続待ちとコマンド実行のタイムアウトを分離し、接続確立に時間がかかった場合でもコマンド応答時間を確保

`ShortcutExecuteActivity` は、MacroDroidなどの自動化アプリが保存したショートカットIntentを後から実行できるよう `exported=true` としています。

一方で、任意の外部アプリからデバイスIDと操作内容を指定して実行されないよう、Android KeyStore上のインストール固有HMACキーを使用したcapability tokenでショートカットを認証します。

## SDK修正

SESAME 5 の明示的な施錠 / 解錠操作における、BLEからIoTへのフォールバック処理を修正します。

従来はコマンド送信時にBLEが利用できなくなった場合、施錠または解錠の要求がIoTの `toggle` コマンドへ置き換わる可能性がありました。

フォールバック後も、元々要求された `lock` / `unlock` が維持されるよう修正しています。

## Before / After

### Before
`ACTION_CREATE_SHORTCUT` は登録されていましたが、実際の作成フローがなく、MacroDroid などから選択しても通常のアプリ画面が開くだけでした。

### After
デバイスと操作を選択して実行用 Intent を保存できるようになり、作成したショートカットから通常画面を開かずに SESAME を直接操作できます。

## 動作確認

- `./gradlew assembleDebug` — 成功
- `./gradlew testDebugUnitTest` — shortcut関連テスト 13/13 成功
  - Contract: 6件
  - DeviceKind: 5件
  - ExecutorPolicy: 2件
- Android実機 + MacroDroidで `ACTION_CREATE_SHORTCUT` によるショートカット作成を確認
- MacroDroidに保存したショートカットから、実際のSESAMEデバイスを正常に操作できることを確認
  - SESAME 4
  - SESAME Bot 1